### PR TITLE
Added the few missing steps to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-Use docker and docker-compose to get up-and-running quick. Make sure that you have the latest version of docker-compose (install via `pip install docker-compose`). Start the web/app/mongo server by doing `docker-compose up` and check your localhost:80. Any time you change the API, you have to stop running the containers, do a`docker-compose build`, and then re-run `docker-compose up`.
+# Quickstart
+
+```
+pip install docker-compose && npm install
+docker-compose up
+```
+Then, open http://localhost:80. Your changes to Angular will take effect once you reload your browser.
+
+If you make changes to the backend services, you'll need to rebuild the api container; do that with `docker-compose build`.


### PR DESCRIPTION
I ran into a problem when demonstrating this to Phil that my instructions skipped installing the JS dependencies for the Angular app. So, I've reworked the readme to include those steps, and I've restructured the bottom bit to be a bit clearer.